### PR TITLE
Fix for faulty topological sort in precompilation

### DIFF
--- a/src/Freya.Machine/Precompilation.fs
+++ b/src/Freya.Machine/Precompilation.fs
@@ -86,7 +86,7 @@ let private independent graph =
 
 let rec private sort extensions graph =
     match independent graph with
-    | Some (e, g) -> sort (e :: extensions) g
+    | Some (e, g) -> sort (extensions @ [ e ]) g
     | _ when Graph.isEmpty graph -> Ordered extensions
     | _ -> Ordering.Error "Extension Dependencies Cyclic"
 


### PR DESCRIPTION
For the last time Andrew, APpend, not PREpend... Should now fix a fairly critical flaw... @panesofglass - feel free to merge this unless you see anything insanely wrong - or I can if you don't get to it - I'll break my "no merging your own pull requests" rule for things like this!