### PR TITLE
Work on type system improvements, plus an first version of typed URI Templates

### DIFF
--- a/Freya.sln
+++ b/Freya.sln
@@ -71,6 +71,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "types", "types", "{BB3531B7
 		tests\Freya.Types.Http.Tests\Freya.Types.Http.Tests.fsproj.paket.references = tests\Freya.Types.Http.Tests\Freya.Types.Http.Tests.fsproj.paket.references
 		tests\Freya.Types.Language.Tests\Freya.Types.Language.Tests.fsproj.paket.references = tests\Freya.Types.Language.Tests\Freya.Types.Language.Tests.fsproj.paket.references
 		tests\Freya.Types.Tests\Freya.Types.Tests.fsproj.paket.references = tests\Freya.Types.Tests\Freya.Types.Tests.fsproj.paket.references
+		tests\Freya.Types.Uri.Template.Tests\Freya.Types.Uri.Template.Tests.fsproj.paket.references = tests\Freya.Types.Uri.Template.Tests\Freya.Types.Uri.Template.Tests.fsproj.paket.references
 		tests\Freya.Types.Uri.Tests\Freya.Types.Uri.Tests.fsproj.paket.references = tests\Freya.Types.Uri.Tests\Freya.Types.Uri.Tests.fsproj.paket.references
 	EndProjectSection
 EndProject
@@ -114,6 +115,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "types", "types", "{064B6AC7
 		src\Freya.Types.Http\Freya.Types.Http.fsproj.paket.references = src\Freya.Types.Http\Freya.Types.Http.fsproj.paket.references
 		src\Freya.Types.Language\Freya.Types.Language.fsproj.paket.references = src\Freya.Types.Language\Freya.Types.Language.fsproj.paket.references
 		src\Freya.Types.Uri\Freya.Types.Uri.fsproj.paket.references = src\Freya.Types.Uri\Freya.Types.Uri.fsproj.paket.references
+		src\Freya.Types.Uri.Template\Freya.Types.Uri.Template.fsproj.paket.references = src\Freya.Types.Uri.Template\Freya.Types.Uri.Template.fsproj.paket.references
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{4B77A140-D2FF-4C67-BD08-8C0081221263}"
@@ -183,6 +185,10 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Freya.Integration.Tests", "tests\Freya.Integration.Tests\Freya.Integration.Tests.fsproj", "{D7B4915E-910C-476D-A2AA-B48991F11E17}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Freya.Integration", "src\Freya.Integration\Freya.Integration.fsproj", "{FDF2C01F-7420-4E1D-8BA1-382C3D801C0C}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Freya.Types.Uri.Template", "src\Freya.Types.Uri.Template\Freya.Types.Uri.Template.fsproj", "{CD9E9BC2-B760-4414-9F78-F0CD1A6BD721}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Freya.Types.Uri.Template.Tests", "tests\Freya.Types.Uri.Template.Tests\Freya.Types.Uri.Template.Tests.fsproj", "{069C35A0-A4C7-423C-87F6-0A4EF964F95A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -302,6 +308,14 @@ Global
 		{FDF2C01F-7420-4E1D-8BA1-382C3D801C0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDF2C01F-7420-4E1D-8BA1-382C3D801C0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDF2C01F-7420-4E1D-8BA1-382C3D801C0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD9E9BC2-B760-4414-9F78-F0CD1A6BD721}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD9E9BC2-B760-4414-9F78-F0CD1A6BD721}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD9E9BC2-B760-4414-9F78-F0CD1A6BD721}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD9E9BC2-B760-4414-9F78-F0CD1A6BD721}.Release|Any CPU.Build.0 = Release|Any CPU
+		{069C35A0-A4C7-423C-87F6-0A4EF964F95A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{069C35A0-A4C7-423C-87F6-0A4EF964F95A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{069C35A0-A4C7-423C-87F6-0A4EF964F95A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{069C35A0-A4C7-423C-87F6-0A4EF964F95A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -361,5 +375,7 @@ Global
 		{FAEE6BC0-D651-4CE8-AA47-F47CAC0FE932} = {32CC81FC-D42C-4D92-A7A6-2304B96EF95E}
 		{D7B4915E-910C-476D-A2AA-B48991F11E17} = {87F63A63-9BE7-408B-937D-A4174FCE5734}
 		{FDF2C01F-7420-4E1D-8BA1-382C3D801C0C} = {435075A8-2EA8-4D8F-9665-00E845BB5CA8}
+		{CD9E9BC2-B760-4414-9F78-F0CD1A6BD721} = {88C54E9A-5D3E-427D-97F8-E7E172E98513}
+		{069C35A0-A4C7-423C-87F6-0A4EF964F95A} = {EB3B4A54-7B25-4AAE-ABEA-4AF38F5E12EF}
 	EndGlobalSection
 EndGlobal

--- a/paket.lock
+++ b/paket.lock
@@ -2,11 +2,11 @@ NUGET
   remote: https://nuget.org/api/v2
   specs:
     Aether (6.0)
-    Chiron (0.1.8-alpha)
+    Chiron (1.0.0)
       Aether (>= 6.0.0)
       FParsec (>= 1.0.1)
       FSharp.Core (>= 3.1.2.1)
-    FAKE (3.17.2)
+    FAKE (3.23.0)
     FParsec (1.0.1)
     FSharp.Core (3.1.2.1)
     Hekate (0.3.0)

--- a/src/Freya.Inspector/Content.fs
+++ b/src/Freya.Inspector/Content.fs
@@ -58,19 +58,19 @@ let private css =
     freyaMachine {
         including defaults
         mediaTypesSupported css
-        handleOk getCss } |> Machine.toPipeline
+        handleOk getCss } |> FreyaMachine.toPipeline
 
 let private html =
     freyaMachine {
         including defaults
         mediaTypesSupported html
-        handleOk getHtml } |> Machine.toPipeline
+        handleOk getHtml } |> FreyaMachine.toPipeline
 
 let private js =
     freyaMachine {
         including defaults
         mediaTypesSupported js
-        handleOk getJs } |> Machine.toPipeline
+        handleOk getJs } |> FreyaMachine.toPipeline
 
 (* Routes
 
@@ -83,4 +83,4 @@ let content =
     freyaRouter {
         resource "/freya/inspector" html
         resource "/freya/css/app.css" css
-        resource "/freya/js/app.js" js } |> Router.toPipeline
+        resource "/freya/js/app.js" js } |> FreyaRouter.toPipeline

--- a/src/Freya.Inspector/Data.fs
+++ b/src/Freya.Inspector/Data.fs
@@ -99,21 +99,21 @@ let private records =
     freyaMachine {
         including defaults
         handleOk recordsGet
-        mediaTypesSupported Prelude.json } |> Machine.toPipeline
+        mediaTypesSupported Prelude.json } |> FreyaMachine.toPipeline
 
 let private record =
     freyaMachine {
         including defaults
         exists recordExists
         handleOk recordGet
-        mediaTypesSupported Prelude.json } |> Machine.toPipeline
+        mediaTypesSupported Prelude.json } |> FreyaMachine.toPipeline
 
 let private inspection inspectors =
     freyaMachine {
         including defaults
         exists (inspectionExists inspectors)
         handleOk (inspectionGet inspectors)
-        mediaTypesSupported Prelude.json } |> Machine.toPipeline
+        mediaTypesSupported Prelude.json } |> FreyaMachine.toPipeline
 
 (* Routes
 
@@ -130,4 +130,4 @@ let data config =
     freyaRouter {
         resource "/freya/inspector/api/records" records
         resource "/freya/inspector/api/records/:id" record
-        resource "/freya/inspector/api/records/:id/extensions/:ext" inspectors } |> Router.toPipeline
+        resource "/freya/inspector/api/records/:id/extensions/:ext" inspectors } |> FreyaRouter.toPipeline

--- a/src/Freya.Machine/Machine.fs
+++ b/src/Freya.Machine/Machine.fs
@@ -19,7 +19,7 @@
 //----------------------------------------------------------------------------
 
 [<RequireQualifiedAccess>]
-module Freya.Machine.Machine
+module Freya.Machine.FreyaMachine
 
 open Freya.Pipeline
 

--- a/src/Freya.Router/Router.fs
+++ b/src/Freya.Router/Router.fs
@@ -19,7 +19,7 @@
 //----------------------------------------------------------------------------
 
 [<RequireQualifiedAccess>]
-module Freya.Router.Router
+module Freya.Router.FreyaRouter
 
 open Freya.Pipeline
 

--- a/src/Freya.Types.Http.Cors/Types.fs
+++ b/src/Freya.Types.Http.Cors/Types.fs
@@ -47,25 +47,25 @@ open FParsec
 type Origin =
     | Origin of OriginListOrNull
 
-    static member TypeMapping =
+    static member Mapping =
 
         let originP =
-            OriginListOrNull.TypeMapping.Parse |>> Origin
+            OriginListOrNull.Mapping.Parse |>> Origin
 
         let originF =
-            function | Origin x -> OriginListOrNull.TypeMapping.Format x
+            function | Origin x -> OriginListOrNull.Mapping.Format x
 
         { Parse = originP
           Format = originF }
 
     static member Format =
-        Formatting.format Origin.TypeMapping.Format
+        Formatting.format Origin.Mapping.Format
 
     static member Parse =
-        Parsing.parse Origin.TypeMapping.Parse
+        Parsing.parse Origin.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Origin.TypeMapping.Parse
+        Parsing.tryParse Origin.Mapping.Parse
 
     override x.ToString () =
         Origin.Format x
@@ -74,15 +74,15 @@ and OriginListOrNull =
     | Origins of SerializedOrigin list
     | Null
 
-    static member TypeMapping =
+    static member Mapping =
 
         let originListOrNullP =
             choice [
-                attempt (sepBy1 SerializedOrigin.TypeMapping.Parse spaceP) |>> Origins
+                attempt (sepBy1 SerializedOrigin.Mapping.Parse spaceP) |>> Origins
                 skipString "null" >>% Null ]
 
         let originListOrNullF =
-            function | Origins x -> join SerializedOrigin.TypeMapping.Format spaceF x
+            function | Origins x -> join SerializedOrigin.Mapping.Format spaceF x
                      | Null -> append "null"
 
         { Parse = originListOrNullP
@@ -91,24 +91,25 @@ and OriginListOrNull =
 and SerializedOrigin =
     | SerializedOrigin of Scheme * Host * Port option
 
-    static member TypeMapping =
+    static member Mapping =
 
         let serializedOriginP =
-            Scheme.TypeMapping.Parse .>> skipString "://" 
-            .>>. Host.TypeMapping.Parse
-            .>>. opt Port.TypeMapping.Parse
-            |>> fun ((scheme, host), port) ->
+                 Scheme.Mapping.Parse .>> skipString "://" 
+            .>>. Host.Mapping.Parse
+            .>>. opt Port.Mapping.Parse
+             |>> fun ((scheme, host), port) ->
                 SerializedOrigin (scheme, host, port)
 
         let serializedOriginF =
             function | SerializedOrigin (s, h, p) ->
                             let formatters =
-                                [ Scheme.TypeMapping.Format s
+                                [ Scheme.Mapping.Format s
                                   append "://"
-                                  Host.TypeMapping.Format h
-                                  (function | Some p -> Port.TypeMapping.Format p | _ -> id) p ]
+                                  Host.Mapping.Format h
+                                  (function | Some p -> Port.Mapping.Format p
+                                            | _ -> id) p ]
 
-                            fun b -> List.fold (fun b f -> f b) b formatters
+                            fun b -> List.fold (|>) b formatters
 
         { Parse = serializedOriginP
           Format = serializedOriginF }
@@ -128,28 +129,28 @@ and SerializedOrigin =
 type AccessControlAllowOrigin =
     | AccessControlAllowOrigin of AccessControlAllowOriginRange
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlAllowOriginP =
             choice [
-                attempt OriginListOrNull.TypeMapping.Parse |>> (Origins >> AccessControlAllowOrigin)
+                attempt OriginListOrNull.Mapping.Parse |>> (Origins >> AccessControlAllowOrigin)
                 skipChar '*' >>% AccessControlAllowOrigin (Any) ]
 
         let accessControlAllowOriginF =
-            function | AccessControlAllowOrigin (Origins x) -> OriginListOrNull.TypeMapping.Format x
+            function | AccessControlAllowOrigin (Origins x) -> OriginListOrNull.Mapping.Format x
                      | AccessControlAllowOrigin (Any) -> append "*"
 
         { Parse = accessControlAllowOriginP
           Format = accessControlAllowOriginF }
 
     static member Format =
-        Formatting.format AccessControlAllowOrigin.TypeMapping.Format
+        Formatting.format AccessControlAllowOrigin.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlAllowOrigin.TypeMapping.Parse
+        Parsing.parse AccessControlAllowOrigin.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlAllowOrigin.TypeMapping.Parse
+        Parsing.tryParse AccessControlAllowOrigin.Mapping.Parse
 
     override x.ToString () =
         AccessControlAllowOrigin.Format x
@@ -166,7 +167,7 @@ and AccessControlAllowOriginRange =
 type AccessControlAllowCredentials =
     | AccessControlAllowCredentials
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlAllowCredentialsP =
             skipString "true" >>% AccessControlAllowCredentials
@@ -178,13 +179,13 @@ type AccessControlAllowCredentials =
           Format = accessControlAllowCredentialsF }
 
     static member Format =
-        Formatting.format AccessControlAllowCredentials.TypeMapping.Format
+        Formatting.format AccessControlAllowCredentials.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlAllowCredentials.TypeMapping.Parse
+        Parsing.parse AccessControlAllowCredentials.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlAllowCredentials.TypeMapping.Parse
+        Parsing.tryParse AccessControlAllowCredentials.Mapping.Parse
 
     override x.ToString () =
         AccessControlAllowCredentials.Format x
@@ -197,7 +198,7 @@ type AccessControlAllowCredentials =
 type AccessControlExposeHeaders =
     | AccessControlExposeHeaders of string list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlExposeHeadersP =
             infixP tokenP commaP |>> AccessControlExposeHeaders
@@ -209,13 +210,13 @@ type AccessControlExposeHeaders =
           Format = accessControlExposeHeadersF }
 
     static member Format =
-        Formatting.format AccessControlExposeHeaders.TypeMapping.Format
+        Formatting.format AccessControlExposeHeaders.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlExposeHeaders.TypeMapping.Parse
+        Parsing.parse AccessControlExposeHeaders.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlExposeHeaders.TypeMapping.Parse
+        Parsing.tryParse AccessControlExposeHeaders.Mapping.Parse
 
     override x.ToString () =
         AccessControlExposeHeaders.Format x
@@ -228,7 +229,7 @@ type AccessControlExposeHeaders =
 type AccessControlMaxAge =
     | AccessControlMaxAge of TimeSpan
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlMaxAgeP =
             puint32 |>> (float >> TimeSpan.FromSeconds >> AccessControlMaxAge)
@@ -240,13 +241,13 @@ type AccessControlMaxAge =
           Format = accessControlMaxAgeF }
 
     static member Format =
-        Formatting.format AccessControlMaxAge.TypeMapping.Format
+        Formatting.format AccessControlMaxAge.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlMaxAge.TypeMapping.Parse
+        Parsing.parse AccessControlMaxAge.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlMaxAge.TypeMapping.Parse
+        Parsing.tryParse AccessControlMaxAge.Mapping.Parse
 
     override x.ToString () =
         AccessControlMaxAge.Format x
@@ -259,25 +260,25 @@ type AccessControlMaxAge =
 type AccessControlAllowMethods =
     | AccessControlAllowMethods of Method list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlAllowMethodsP =
-            infixP Method.TypeMapping.Parse commaP |>> AccessControlAllowMethods
+            infixP Method.Mapping.Parse commaP |>> AccessControlAllowMethods
 
         let accessControlAllowMethodsF =
-            function | AccessControlAllowMethods x -> join Method.TypeMapping.Format commaF x
+            function | AccessControlAllowMethods x -> join Method.Mapping.Format commaF x
 
         { Parse = accessControlAllowMethodsP
           Format = accessControlAllowMethodsF }
 
     static member Format =
-        Formatting.format AccessControlAllowMethods.TypeMapping.Format
+        Formatting.format AccessControlAllowMethods.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlAllowMethods.TypeMapping.Parse
+        Parsing.parse AccessControlAllowMethods.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlAllowMethods.TypeMapping.Parse
+        Parsing.tryParse AccessControlAllowMethods.Mapping.Parse
 
     override x.ToString () =
         AccessControlAllowMethods.Format x
@@ -290,7 +291,7 @@ type AccessControlAllowMethods =
 type AccessControlAllowHeaders =
     | AccessControlAllowHeaders of string list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlAllowHeadersP =
             infixP tokenP commaP |>> AccessControlAllowHeaders
@@ -302,13 +303,13 @@ type AccessControlAllowHeaders =
           Format = accessControlAllowHeadersF }
 
     static member Format =
-        Formatting.format AccessControlAllowHeaders.TypeMapping.Format
+        Formatting.format AccessControlAllowHeaders.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlAllowHeaders.TypeMapping.Parse
+        Parsing.parse AccessControlAllowHeaders.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlAllowHeaders.TypeMapping.Parse
+        Parsing.tryParse AccessControlAllowHeaders.Mapping.Parse
 
     override x.ToString () =
         AccessControlAllowHeaders.Format x
@@ -321,25 +322,25 @@ type AccessControlAllowHeaders =
 type AccessControlRequestMethod =
     | AccessControlRequestMethod of Method
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlRequestMethodP =
-            Method.TypeMapping.Parse |>> AccessControlRequestMethod
+            Method.Mapping.Parse |>> AccessControlRequestMethod
 
         let accessControlRequestMethodF =
-            function | AccessControlRequestMethod x -> Method.TypeMapping.Format x
+            function | AccessControlRequestMethod x -> Method.Mapping.Format x
 
         { Parse = accessControlRequestMethodP
           Format = accessControlRequestMethodF }
 
     static member Format =
-        Formatting.format AccessControlRequestMethod.TypeMapping.Format
+        Formatting.format AccessControlRequestMethod.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlRequestMethod.TypeMapping.Parse
+        Parsing.parse AccessControlRequestMethod.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlRequestMethod.TypeMapping.Parse
+        Parsing.tryParse AccessControlRequestMethod.Mapping.Parse
 
     override x.ToString () =
         AccessControlRequestMethod.Format x
@@ -352,7 +353,7 @@ type AccessControlRequestMethod =
 type AccessControlRequestHeaders =
     | AccessControlRequestHeaders of string list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let accessControlRequestHeadersP =
             infixP tokenP commaP |>> AccessControlRequestHeaders
@@ -364,13 +365,13 @@ type AccessControlRequestHeaders =
           Format = accessControlRequestHeadersF }
 
     static member Format =
-        Formatting.format AccessControlRequestHeaders.TypeMapping.Format
+        Formatting.format AccessControlRequestHeaders.Mapping.Format
 
     static member Parse =
-        Parsing.parse AccessControlRequestHeaders.TypeMapping.Parse
+        Parsing.parse AccessControlRequestHeaders.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AccessControlRequestHeaders.TypeMapping.Parse
+        Parsing.tryParse AccessControlRequestHeaders.Mapping.Parse
 
     override x.ToString () =
         AccessControlRequestHeaders.Format x

--- a/src/Freya.Types.Http/Types.fs
+++ b/src/Freya.Types.Http/Types.fs
@@ -53,17 +53,17 @@ type PartialUri =
     | PartialUri of RelativePart * Query option
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let partialUriP =
-            RelativePart.TypeMapping.Parse .>>. opt Query.TypeMapping.Parse
+            RelativePart.Mapping.Parse .>>. opt Query.Mapping.Parse
             |>> PartialUri
 
         let partialUriF =
             function | PartialUri (r, q) ->
                         let formatters =
-                            [ RelativePart.TypeMapping.Format r
-                              (function | Some q -> Query.TypeMapping.Format q | _ -> id) q ]
+                            [ RelativePart.Mapping.Format r
+                              (function | Some q -> Query.Mapping.Format q | _ -> id) q ]
 
                         fun b -> List.fold (|>) b formatters
 
@@ -71,13 +71,13 @@ type PartialUri =
           Format = partialUriF }
 
     static member Format =
-        Formatting.format PartialUri.TypeMapping.Format
+        Formatting.format PartialUri.Mapping.Format
 
     static member Parse =
-        Parsing.parse PartialUri.TypeMapping.Parse
+        Parsing.parse PartialUri.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse PartialUri.TypeMapping.Parse
+        Parsing.tryParse PartialUri.Mapping.Parse
 
     override x.ToString () =
         PartialUri.Format x
@@ -180,7 +180,7 @@ type HttpVersion =
     | Custom of string
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let httpVersionP =
             choice [
@@ -196,13 +196,13 @@ type HttpVersion =
           Format = httpVersionF }
 
     static member Format =
-        Formatting.format HttpVersion.TypeMapping.Format
+        Formatting.format HttpVersion.Mapping.Format
 
     static member Parse =
-        Parsing.parse HttpVersion.TypeMapping.Parse
+        Parsing.parse HttpVersion.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse HttpVersion.TypeMapping.Parse
+        Parsing.tryParse HttpVersion.Mapping.Parse
 
     override x.ToString () =
         HttpVersion.Format x
@@ -216,7 +216,7 @@ type ContentLength =
     | ContentLength of int
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let contentLengthP =
             puint32 |>> (int >> ContentLength)
@@ -228,13 +228,13 @@ type ContentLength =
           Format = contentLengthF }
 
     static member Format =
-        Formatting.format ContentLength.TypeMapping.Format
+        Formatting.format ContentLength.Mapping.Format
 
     static member Parse =
-        Parsing.parse ContentLength.TypeMapping.Parse
+        Parsing.parse ContentLength.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse ContentLength.TypeMapping.Parse
+        Parsing.tryParse ContentLength.Mapping.Parse
 
     override x.ToString () =
         ContentLength.Format x
@@ -248,16 +248,17 @@ type Host =
     | Host of Uri.Host * Port option
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let hostP =
-            Uri.Host.TypeMapping.Parse .>>. opt Port.TypeMapping.Parse |>> Host
+            Uri.Host.Mapping.Parse .>>. opt Port.Mapping.Parse |>> Host
 
         let hostF =
             function | Host (h, p) ->
                         let formatters =
-                            [ Uri.Host.TypeMapping.Format h
-                              (function | Some p -> Port.TypeMapping.Format p | _ -> id) p ]
+                            [ Uri.Host.Mapping.Format h
+                              (function | Some p -> Port.Mapping.Format p
+                                        | _ -> id) p ]
 
                         fun b -> List.fold (|>) b formatters
 
@@ -265,13 +266,13 @@ type Host =
           Format = hostF }
 
     static member Format =
-        Formatting.format Host.TypeMapping.Format
+        Formatting.format Host.Mapping.Format
 
     static member Parse =
-        Parsing.parse Host.TypeMapping.Parse
+        Parsing.parse Host.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Host.TypeMapping.Parse
+        Parsing.tryParse Host.Mapping.Parse
 
     override x.ToString () =
         Host.Format x
@@ -285,7 +286,7 @@ type Connection =
     | Connection of ConnectionOption list
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let connectionP =
             infix1P tokenP commaP |>> (List.map ConnectionOption >> Connection)
@@ -297,13 +298,13 @@ type Connection =
           Format = connectionF }
 
     static member Format =
-        Formatting.format Connection.TypeMapping.Format
+        Formatting.format Connection.Mapping.Format
 
     static member Parse =
-        Parsing.parse Connection.TypeMapping.Parse
+        Parsing.parse Connection.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Connection.TypeMapping.Parse
+        Parsing.tryParse Connection.Mapping.Parse
 
     override x.ToString () =
         Connection.Format x
@@ -329,15 +330,15 @@ and ConnectionOption =
 type MediaType =
     | MediaType of Type * SubType * Parameters
 
-    static member TypeMapping =
+    static member Mapping =
 
         let mediaTypeP =
-            tokenP .>> slashP .>>. tokenP .>>. Parameters.TypeMapping.Parse
+            tokenP .>> slashP .>>. tokenP .>>. Parameters.Mapping.Parse
             |>> (fun ((x, y), p) -> MediaType (Type x, SubType y, p))
 
         let mediaTypeF =
             function | MediaType (Type x, SubType y, p) -> 
-                        appendf2 "{0}/{1}" x y >> Parameters.TypeMapping.Format p
+                        appendf2 "{0}/{1}" x y >> Parameters.Mapping.Format p
 
         { Parse = mediaTypeP
           Format = mediaTypeF }
@@ -356,13 +357,13 @@ type MediaType =
     (* Common *)
 
     static member Format =
-        Formatting.format MediaType.TypeMapping.Format
+        Formatting.format MediaType.Mapping.Format
 
     static member Parse =
-        Parsing.parse MediaType.TypeMapping.Parse
+        Parsing.parse MediaType.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse MediaType.TypeMapping.Parse
+        Parsing.tryParse MediaType.Mapping.Parse
 
     override x.ToString () =
         MediaType.Format x
@@ -371,7 +372,7 @@ type MediaType =
 and Parameters =
     | Parameters of Map<string, string>
 
-    static member TypeMapping =
+    static member Mapping =
 
         let parameterP =
             tokenP .>> skipChar '=' .>>. (quotedStringP <|> tokenP)
@@ -430,13 +431,13 @@ type MediaType with
 type ContentType =
     | ContentType of MediaType
 
-    static member TypeMapping =
+    static member Mapping =
 
         let contentTypeP =
-            MediaType.TypeMapping.Parse |>> ContentType
+            MediaType.Mapping.Parse |>> ContentType
 
         let contentTypeF =
-            function | ContentType x -> MediaType.TypeMapping.Format x
+            function | ContentType x -> MediaType.Mapping.Format x
 
         { Parse = contentTypeP
           Format = contentTypeF }
@@ -449,13 +450,13 @@ type ContentType =
     (* Common *)
 
     static member Format =
-        Formatting.format ContentType.TypeMapping.Format
+        Formatting.format ContentType.Mapping.Format
 
     static member Parse =
-        Parsing.parse ContentType.TypeMapping.Parse
+        Parsing.parse ContentType.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse ContentType.TypeMapping.Parse
+        Parsing.tryParse ContentType.Mapping.Parse
 
     override x.ToString () =
         ContentType.Format x
@@ -468,7 +469,7 @@ type ContentType =
 type ContentEncoding =
     | ContentEncoding of ContentCoding list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let contentEncodingP =
             infix1P tokenP commaP |>> (List.map ContentCoding >> ContentEncoding)
@@ -480,13 +481,13 @@ type ContentEncoding =
           Format = contentEncodingF }
 
     static member Format =
-        Formatting.format ContentEncoding.TypeMapping.Format
+        Formatting.format ContentEncoding.Mapping.Format
 
     static member Parse =
-        Parsing.parse ContentEncoding.TypeMapping.Parse
+        Parsing.parse ContentEncoding.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse ContentEncoding.TypeMapping.Parse
+        Parsing.tryParse ContentEncoding.Mapping.Parse
 
     override x.ToString () =
         ContentEncoding.Format x
@@ -518,25 +519,25 @@ type ContentCoding with
 type ContentLanguage =
     | ContentLanguage of LanguageTag list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let contentLanguageP =
-            infix1P LanguageTag.TypeMapping.Parse commaP |>> ContentLanguage
+            infix1P LanguageTag.Mapping.Parse commaP |>> ContentLanguage
 
         let contentLanguageF =
-            function | ContentLanguage xs -> join LanguageTag.TypeMapping.Format commaF xs
+            function | ContentLanguage xs -> join LanguageTag.Mapping.Format commaF xs
 
         { Parse = contentLanguageP
           Format = contentLanguageF }
 
     static member Format =
-        Formatting.format ContentLanguage.TypeMapping.Format
+        Formatting.format ContentLanguage.Mapping.Format
 
     static member Parse =
-        Parsing.parse ContentLanguage.TypeMapping.Parse
+        Parsing.parse ContentLanguage.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse ContentLanguage.TypeMapping.Parse
+        Parsing.tryParse ContentLanguage.Mapping.Parse
 
     override x.ToString () =
         ContentLanguage.Format x
@@ -549,28 +550,28 @@ type ContentLanguage =
 type ContentLocation =
     | ContentLocation of ContentLocationUri
 
-    static member TypeMapping =
+    static member Mapping =
 
         let contentLocationP =
             choice [
-                attempt AbsoluteUri.TypeMapping.Parse |>> (Absolute >> ContentLocation)
-                PartialUri.TypeMapping.Parse |>> (Partial >> ContentLocation) ]
+                attempt AbsoluteUri.Mapping.Parse |>> (Absolute >> ContentLocation)
+                PartialUri.Mapping.Parse |>> (Partial >> ContentLocation) ]
 
         let contentLocationF =
-            function | ContentLocation (Absolute x) -> AbsoluteUri.TypeMapping.Format x
-                     | ContentLocation (Partial x) -> PartialUri.TypeMapping.Format x
+            function | ContentLocation (Absolute x) -> AbsoluteUri.Mapping.Format x
+                     | ContentLocation (Partial x) -> PartialUri.Mapping.Format x
 
         { Parse = contentLocationP
           Format = contentLocationF }
 
     static member Format =
-        Formatting.format ContentLocation.TypeMapping.Format
+        Formatting.format ContentLocation.Mapping.Format
 
     static member Parse =
-        Parsing.parse ContentLocation.TypeMapping.Parse
+        Parsing.parse ContentLocation.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse ContentLocation.TypeMapping.Parse
+        Parsing.tryParse ContentLocation.Mapping.Parse
 
     override x.ToString () =
         ContentLocation.Format x
@@ -595,7 +596,7 @@ type Method =
     | TRACE 
     | Custom of string
 
-    static member TypeMapping =
+    static member Mapping =
 
         let methodP =
             choice [
@@ -624,10 +625,10 @@ type Method =
           Format = methodF }
 
     static member Format =
-        Formatting.format Method.TypeMapping.Format
+        Formatting.format Method.Mapping.Format
 
     static member Parse =
-        Parsing.parse Method.TypeMapping.Parse
+        Parsing.parse Method.Mapping.Parse
 
     override x.ToString () =
         Method.Format x
@@ -640,7 +641,7 @@ type Method =
 type Expect =
     | Expect of Continue
 
-    static member TypeMapping =
+    static member Mapping =
 
         let expectP =
             skipStringCI "100-continue" >>% Expect Continue
@@ -652,13 +653,13 @@ type Expect =
           Format = expectF }
 
     static member Format =
-        Formatting.format Expect.TypeMapping.Format
+        Formatting.format Expect.Mapping.Format
 
     static member Parse =
-        Parsing.parse Expect.TypeMapping.Parse
+        Parsing.parse Expect.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Expect.TypeMapping.Parse
+        Parsing.tryParse Expect.Mapping.Parse
 
     override x.ToString () =
         Expect.Format x
@@ -674,7 +675,7 @@ and Continue =
 type MaxForwards =
     | MaxForwards of int
 
-    static member TypeMapping =
+    static member Mapping =
 
         let maxForwardsP =
             puint32 |>> (int >> MaxForwards)
@@ -686,13 +687,13 @@ type MaxForwards =
           Format = maxForwardsF }
 
     static member Format =
-        Formatting.format MaxForwards.TypeMapping.Format
+        Formatting.format MaxForwards.Mapping.Format
 
     static member Parse =
-        Parsing.parse MaxForwards.TypeMapping.Parse
+        Parsing.parse MaxForwards.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse MaxForwards.TypeMapping.Parse
+        Parsing.tryParse MaxForwards.Mapping.Parse
 
     override x.ToString () =
         MaxForwards.Format x
@@ -705,7 +706,7 @@ type MaxForwards =
 type Weight =
     | Weight of float
 
-    static member TypeMapping =
+    static member Mapping =
 
         let valueOrDefault =
             function | Some x -> float (sprintf "0.%s" x)
@@ -741,25 +742,25 @@ type Weight =
 type Accept =
     | Accept of AcceptableMedia list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptP =
-            infixP AcceptableMedia.TypeMapping.Parse commaP |>> Accept
+            infixP AcceptableMedia.Mapping.Parse commaP |>> Accept
 
         let acceptF =
-            function | Accept x -> join AcceptableMedia.TypeMapping.Format commaF x
+            function | Accept x -> join AcceptableMedia.Mapping.Format commaF x
 
         { Parse = acceptP
           Format = acceptF }
 
     static member Format =
-        Formatting.format Accept.TypeMapping.Format
+        Formatting.format Accept.Mapping.Format
 
     static member Parse =
-        Parsing.parse Accept.TypeMapping.Parse
+        Parsing.parse Accept.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Accept.TypeMapping.Parse
+        Parsing.tryParse Accept.Mapping.Parse
 
     override x.ToString () =
         Accept.Format x
@@ -767,16 +768,16 @@ type Accept =
 and AcceptableMedia =
     | AcceptableMedia of MediaRange * AcceptParameters option
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptableMediaP = 
-            MediaRange.TypeMapping.Parse .>>. opt AcceptParameters.TypeMapping.Parse
+            MediaRange.Mapping.Parse .>>. opt AcceptParameters.Mapping.Parse
             |>> AcceptableMedia
 
         let acceptableMediaF =
             function | AcceptableMedia (m, p) -> 
-                         MediaRange.TypeMapping.Format m 
-                         >> (function | Some p -> AcceptParameters.TypeMapping.Format p
+                         MediaRange.Mapping.Format m 
+                         >> (function | Some p -> AcceptParameters.Mapping.Format p
                                       | _ -> id) p
 
         { Parse = acceptableMediaP
@@ -787,7 +788,7 @@ and MediaRange =
     | Partial of Type * Parameters
     | Open of Parameters
 
-    static member TypeMapping =
+    static member Mapping =
 
         let mediaRangeParameterP =
             notFollowedBy (owsP >>. skipStringCI "q=") >>. tokenP .>> skipChar '=' .>>. tokenP
@@ -815,9 +816,9 @@ and MediaRange =
                 closedMediaRangeP ]
 
         let mediaRangeF =
-            function | MediaRange.Closed (Type x, SubType y, p) -> appendf2 "{0}/{1}" x y >> Parameters.TypeMapping.Format p
-                     | MediaRange.Partial (Type x, p) -> appendf1 "{0}/*" x >> Parameters.TypeMapping.Format p
-                     | MediaRange.Open p -> append "*/*" >> Parameters.TypeMapping.Format p
+            function | MediaRange.Closed (Type x, SubType y, p) -> appendf2 "{0}/{1}" x y >> Parameters.Mapping.Format p
+                     | MediaRange.Partial (Type x, p) -> appendf1 "{0}/*" x >> Parameters.Mapping.Format p
+                     | MediaRange.Open p -> append "*/*" >> Parameters.Mapping.Format p
 
         { Parse = mediaRangeP
           Format = mediaRangeF }
@@ -825,15 +826,15 @@ and MediaRange =
 and AcceptParameters =
     | AcceptParameters of Weight * AcceptExtensions
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptParamsP =
-            Weight.TypeMapping.Parse .>> owsP .>>. AcceptExtensions.TypeMapping.Parse
+            Weight.Mapping.Parse .>> owsP .>>. AcceptExtensions.Mapping.Parse
             |>> AcceptParameters
 
         let acceptParamsF =
             function | AcceptParameters (w, e) -> 
-                        Weight.TypeMapping.Format w >> AcceptExtensions.TypeMapping.Format e
+                        Weight.Mapping.Format w >> AcceptExtensions.Mapping.Format e
 
         { Parse = acceptParamsP
           Format = acceptParamsF }
@@ -841,7 +842,7 @@ and AcceptParameters =
 and AcceptExtensions =
     | Extensions of Map<string, string option>
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptExtP =
             tokenP .>>. opt (skipChar '=' >>. (quotedStringP <|> tokenP))
@@ -864,27 +865,27 @@ and AcceptExtensions =
 type AcceptCharset =
     | AcceptCharset of AcceptableCharset list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptCharsetP =
-            infix1P AcceptableCharset.TypeMapping.Parse commaP
+            infix1P AcceptableCharset.Mapping.Parse commaP
             |>> AcceptCharset
 
         let acceptCharsetF =
             function | AcceptCharset x ->
-                        join AcceptableCharset.TypeMapping.Format commaF x
+                        join AcceptableCharset.Mapping.Format commaF x
 
         { Parse = acceptCharsetP
           Format = acceptCharsetF }
 
     static member Format =
-        Formatting.format AcceptCharset.TypeMapping.Format
+        Formatting.format AcceptCharset.Mapping.Format
 
     static member Parse =
-        Parsing.parse AcceptCharset.TypeMapping.Parse
+        Parsing.parse AcceptCharset.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AcceptCharset.TypeMapping.Parse
+        Parsing.tryParse AcceptCharset.Mapping.Parse
 
     override x.ToString () =
         AcceptCharset.Format x
@@ -892,16 +893,16 @@ type AcceptCharset =
 and AcceptableCharset =
     | AcceptableCharset of CharsetRange * Weight option
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptableCharsetP =
-            CharsetRange.TypeMapping.Parse .>> owsP .>>. opt Weight.TypeMapping.Parse
+            CharsetRange.Mapping.Parse .>> owsP .>>. opt Weight.Mapping.Parse
             |>> AcceptableCharset
 
         let acceptableCharsetF =
             function | AcceptableCharset (c, w) ->
-                        CharsetRange.TypeMapping.Format c 
-                        >> (function | Some w -> Weight.TypeMapping.Format w
+                        CharsetRange.Mapping.Format c 
+                        >> (function | Some w -> Weight.Mapping.Format w
                                      | _ -> id) w
 
         { Parse = acceptableCharsetP
@@ -911,7 +912,7 @@ and CharsetRange =
     | Charset of Charset
     | Any
 
-    static member TypeMapping =
+    static member Mapping =
 
         let charsetRangeAnyP =
             skipChar '*' >>% CharsetRange.Any
@@ -958,27 +959,27 @@ type Charset with
 type AcceptEncoding =
     | AcceptEncoding of AcceptableEncoding list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptEncodingP =
-            infixP AcceptableEncoding.TypeMapping.Parse commaP
+            infixP AcceptableEncoding.Mapping.Parse commaP
             |>> AcceptEncoding
 
         let acceptEncodingF =
             function | AcceptEncoding x ->
-                        join AcceptableEncoding.TypeMapping.Format commaF x
+                        join AcceptableEncoding.Mapping.Format commaF x
 
         { Parse = acceptEncodingP
           Format = acceptEncodingF }
 
     static member Format =
-        Formatting.format AcceptEncoding.TypeMapping.Format
+        Formatting.format AcceptEncoding.Mapping.Format
 
     static member Parse =
-        Parsing.parse AcceptEncoding.TypeMapping.Parse
+        Parsing.parse AcceptEncoding.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AcceptEncoding.TypeMapping.Parse
+        Parsing.tryParse AcceptEncoding.Mapping.Parse
 
     override x.ToString () =
         AcceptEncoding.Format x
@@ -986,16 +987,16 @@ type AcceptEncoding =
 and AcceptableEncoding =
     | AcceptableEncoding of EncodingRange * Weight option
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptableEncodingP =
-            EncodingRange.TypeMapping.Parse .>> owsP .>>. opt Weight.TypeMapping.Parse
+            EncodingRange.Mapping.Parse .>> owsP .>>. opt Weight.Mapping.Parse
             |>> AcceptableEncoding
 
         let acceptableEncodingF =
             function | AcceptableEncoding (e, w) ->
-                        EncodingRange.TypeMapping.Format e
-                        >> (function | Some w -> Weight.TypeMapping.Format w
+                        EncodingRange.Mapping.Format e
+                        >> (function | Some w -> Weight.Mapping.Format w
                                      | _ -> id) w
 
         { Parse = acceptableEncodingP
@@ -1006,7 +1007,7 @@ and EncodingRange =
     | Identity
     | Any
 
-    static member TypeMapping =
+    static member Mapping =
 
         let encodingRangeAnyP =
             skipChar '*' >>% Any
@@ -1039,27 +1040,27 @@ and EncodingRange =
 type AcceptLanguage =
     | AcceptLanguage of AcceptableLanguage list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptLanguageP =
-            infixP AcceptableLanguage.TypeMapping.Parse commaP
+            infixP AcceptableLanguage.Mapping.Parse commaP
             |>> AcceptLanguage
 
         let acceptLanguageF =
             function | AcceptLanguage x ->
-                        join AcceptableLanguage.TypeMapping.Format commaF x
+                        join AcceptableLanguage.Mapping.Format commaF x
 
         { Parse = acceptLanguageP
           Format = acceptLanguageF }
 
     static member Format =
-        Formatting.format AcceptLanguage.TypeMapping.Format
+        Formatting.format AcceptLanguage.Mapping.Format
 
     static member Parse =
-        Parsing.parse AcceptLanguage.TypeMapping.Parse
+        Parsing.parse AcceptLanguage.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse AcceptLanguage.TypeMapping.Parse
+        Parsing.tryParse AcceptLanguage.Mapping.Parse
 
     override x.ToString () =
         AcceptLanguage.Format x
@@ -1067,16 +1068,16 @@ type AcceptLanguage =
 and AcceptableLanguage =
     | AcceptableLanguage of LanguageRange * Weight option
 
-    static member TypeMapping =
+    static member Mapping =
 
         let acceptableLanguageP =
-            LanguageRange.TypeMapping.Parse .>> owsP .>>. opt Weight.TypeMapping.Parse
+            LanguageRange.Mapping.Parse .>> owsP .>>. opt Weight.Mapping.Parse
             |>> AcceptableLanguage
 
         let acceptableLanguageF =
             function | AcceptableLanguage (l, w) ->
-                        LanguageRange.TypeMapping.Format l
-                        >> (function | Some w -> Weight.TypeMapping.Format w
+                        LanguageRange.Mapping.Format l
+                        >> (function | Some w -> Weight.Mapping.Format w
                                      | _ -> id) w
 
         { Parse = acceptableLanguageP
@@ -1090,28 +1091,28 @@ and AcceptableLanguage =
 type Referer =
     | Referer of RefererUri
 
-    static member TypeMapping =
+    static member Mapping =
 
         let refererP =
             choice [
-                attempt AbsoluteUri.TypeMapping.Parse |>> (Absolute >> Referer)
-                PartialUri.TypeMapping.Parse |>> (Partial >> Referer) ]
+                attempt AbsoluteUri.Mapping.Parse |>> (Absolute >> Referer)
+                PartialUri.Mapping.Parse |>> (Partial >> Referer) ]
 
         let refererF =
-            function | Referer (Absolute x) -> AbsoluteUri.TypeMapping.Format x
-                     | Referer (Partial x) -> PartialUri.TypeMapping.Format x
+            function | Referer (Absolute x) -> AbsoluteUri.Mapping.Format x
+                     | Referer (Partial x) -> PartialUri.Mapping.Format x
 
         { Parse = refererP
           Format = refererF }
 
     static member Format =
-        Formatting.format Referer.TypeMapping.Format
+        Formatting.format Referer.Mapping.Format
 
     static member Parse =
-        Parsing.parse Referer.TypeMapping.Parse
+        Parsing.parse Referer.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Referer.TypeMapping.Parse
+        Parsing.tryParse Referer.Mapping.Parse
 
     override x.ToString () =
         Referer.Format x
@@ -1144,7 +1145,7 @@ let internal httpDateP : Parser<DateTime, unit> =
 type Date =
     | Date of DateTime
 
-    static member TypeMapping =
+    static member Mapping =
 
         let dateP =
             httpDateP |>> Date.Date
@@ -1156,13 +1157,13 @@ type Date =
           Format = dateF }
 
     static member Format =
-        Formatting.format Date.TypeMapping.Format
+        Formatting.format Date.Mapping.Format
 
     static member Parse =
-        Parsing.parse Date.TypeMapping.Parse
+        Parsing.parse Date.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Date.TypeMapping.Parse
+        Parsing.tryParse Date.Mapping.Parse
 
     override x.ToString () =
         Date.Format x
@@ -1175,25 +1176,25 @@ type Date =
 type Location =
     | Location of UriReference
 
-    static member TypeMapping =
+    static member Mapping =
 
         let locationP =
-            UriReference.TypeMapping.Parse |>> Location
+            UriReference.Mapping.Parse |>> Location
 
         let locationF =
-            function | Location x -> UriReference.TypeMapping.Format x
+            function | Location x -> UriReference.Mapping.Format x
 
         { Parse = locationP
           Format = locationF }
 
     static member Format =
-        Formatting.format Location.TypeMapping.Format
+        Formatting.format Location.Mapping.Format
 
     static member Parse =
-        Parsing.parse Location.TypeMapping.Parse
+        Parsing.parse Location.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Location.TypeMapping.Parse
+        Parsing.tryParse Location.Mapping.Parse
 
     override x.ToString () =
         Location.Format x
@@ -1206,7 +1207,7 @@ type Location =
 type RetryAfter =
     | RetryAfter of RetryAfterChoice
 
-    static member TypeMapping =
+    static member Mapping =
 
         let retryAfterP =
             choice [
@@ -1221,13 +1222,13 @@ type RetryAfter =
           Format = retryAfterF }
 
     static member Format =
-        Formatting.format RetryAfter.TypeMapping.Format
+        Formatting.format RetryAfter.Mapping.Format
 
     static member Parse =
-        Parsing.parse RetryAfter.TypeMapping.Parse
+        Parsing.parse RetryAfter.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse RetryAfter.TypeMapping.Parse
+        Parsing.tryParse RetryAfter.Mapping.Parse
 
     override x.ToString () =
         RetryAfter.Format x
@@ -1244,25 +1245,25 @@ and RetryAfterChoice =
 type Allow =
     | Allow of Method list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let allowP =
-            infixP Method.TypeMapping.Parse commaP |>> Allow
+            infixP Method.Mapping.Parse commaP |>> Allow
 
         let allowF =
-            function | Allow x -> join Method.TypeMapping.Format commaF x
+            function | Allow x -> join Method.Mapping.Format commaF x
 
         { Parse = allowP
           Format = allowF }
 
     static member Format =
-        Formatting.format Allow.TypeMapping.Format
+        Formatting.format Allow.Mapping.Format
 
     static member Parse =
-        Parsing.parse Allow.TypeMapping.Parse
+        Parsing.parse Allow.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Allow.TypeMapping.Parse
+        Parsing.tryParse Allow.Mapping.Parse
 
     override x.ToString () =
         Allow.Format x
@@ -1282,7 +1283,7 @@ type Allow =
 type LastModified =
     | LastModified of DateTime
 
-    static member TypeMapping =
+    static member Mapping =
 
         let lastModifiedP =
             httpDateP |>> LastModified
@@ -1294,13 +1295,13 @@ type LastModified =
           Format = lastModifiedF }
 
     static member Format =
-        Formatting.format LastModified.TypeMapping.Format
+        Formatting.format LastModified.Mapping.Format
 
     static member Parse =
-        Parsing.parse LastModified.TypeMapping.Parse
+        Parsing.parse LastModified.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse LastModified.TypeMapping.Parse
+        Parsing.tryParse LastModified.Mapping.Parse
 
     override x.ToString () =
         LastModified.Format x
@@ -1313,25 +1314,25 @@ type LastModified =
 type ETag =
     | ETag of EntityTag
 
-    static member TypeMapping =
+    static member Mapping =
 
         let eTagP =
-            EntityTag.TypeMapping.Parse |>> ETag
+            EntityTag.Mapping.Parse |>> ETag
 
         let eTagF =
-            function | ETag x -> EntityTag.TypeMapping.Format x
+            function | ETag x -> EntityTag.Mapping.Format x
 
         { Parse = eTagP
           Format = eTagF }
 
     static member Format =
-        Formatting.format ETag.TypeMapping.Format
+        Formatting.format ETag.Mapping.Format
 
     static member Parse =
-        Parsing.parse ETag.TypeMapping.Parse
+        Parsing.parse ETag.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse ETag.TypeMapping.Parse
+        Parsing.tryParse ETag.Mapping.Parse
 
     override x.ToString () =
         ETag.Format x
@@ -1340,7 +1341,7 @@ and EntityTag =
     | Strong of string
     | Weak of string
 
-    static member TypeMapping =
+    static member Mapping =
 
         let eTagChars =
             Set.unionMany [
@@ -1371,28 +1372,28 @@ and EntityTag =
 type IfMatch =
     | IfMatch of IfMatchChoice
 
-    static member TypeMapping =
+    static member Mapping =
 
         let ifMatchP =
             choice [
                 skipChar '*' >>% IfMatch (Any)
-                infixP EntityTag.TypeMapping.Parse commaP |>> (EntityTags >> IfMatch) ]
+                infixP EntityTag.Mapping.Parse commaP |>> (EntityTags >> IfMatch) ]
 
         let ifMatchF =
-            function | IfMatch (EntityTags x) -> join EntityTag.TypeMapping.Format commaF x
+            function | IfMatch (EntityTags x) -> join EntityTag.Mapping.Format commaF x
                      | IfMatch (Any) -> append "*"
 
         { Parse = ifMatchP
           Format = ifMatchF }
 
     static member Format =
-        Formatting.format IfMatch.TypeMapping.Format
+        Formatting.format IfMatch.Mapping.Format
 
     static member Parse =
-        Parsing.parse IfMatch.TypeMapping.Parse
+        Parsing.parse IfMatch.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse IfMatch.TypeMapping.Parse
+        Parsing.tryParse IfMatch.Mapping.Parse
 
     override x.ToString () =
         IfMatch.Format x
@@ -1409,28 +1410,28 @@ and IfMatchChoice =
 type IfNoneMatch =
     | IfNoneMatch of IfNoneMatchChoice
 
-    static member TypeMapping =
+    static member Mapping =
 
         let ifNoneMatchP =
             choice [
                 skipChar '*' >>% IfNoneMatch (Any)
-                infixP EntityTag.TypeMapping.Parse commaP |>> (EntityTags >> IfNoneMatch) ]
+                infixP EntityTag.Mapping.Parse commaP |>> (EntityTags >> IfNoneMatch) ]
 
         let ifNoneMatchF =
-            function | IfNoneMatch (EntityTags x) -> join EntityTag.TypeMapping.Format commaF x
+            function | IfNoneMatch (EntityTags x) -> join EntityTag.Mapping.Format commaF x
                      | IfNoneMatch (Any) -> append "*"
 
         { Parse = ifNoneMatchP
           Format = ifNoneMatchF }
 
     static member Format =
-        Formatting.format IfNoneMatch.TypeMapping.Format
+        Formatting.format IfNoneMatch.Mapping.Format
 
     static member Parse =
-        Parsing.parse IfNoneMatch.TypeMapping.Parse
+        Parsing.parse IfNoneMatch.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse IfNoneMatch.TypeMapping.Parse
+        Parsing.tryParse IfNoneMatch.Mapping.Parse
 
     override x.ToString () =
         IfNoneMatch.Format x
@@ -1447,7 +1448,7 @@ and IfNoneMatchChoice =
 type IfModifiedSince =
     | IfModifiedSince of DateTime
 
-    static member TypeMapping =
+    static member Mapping =
 
         let ifModifiedSinceP =
             httpDateP |>> IfModifiedSince
@@ -1459,13 +1460,13 @@ type IfModifiedSince =
           Format = ifModifiedSinceF }
 
     static member Format =
-        Formatting.format IfModifiedSince.TypeMapping.Format
+        Formatting.format IfModifiedSince.Mapping.Format
 
     static member Parse =
-        Parsing.parse IfModifiedSince.TypeMapping.Parse
+        Parsing.parse IfModifiedSince.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse IfModifiedSince.TypeMapping.Parse
+        Parsing.tryParse IfModifiedSince.Mapping.Parse
 
     override x.ToString () =
         IfModifiedSince.Format x
@@ -1478,7 +1479,7 @@ type IfModifiedSince =
 type IfUnmodifiedSince =
     | IfUnmodifiedSince of DateTime
 
-    static member TypeMapping =
+    static member Mapping =
 
         let ifUnmodifiedSinceP =
             httpDateP |>> IfUnmodifiedSince
@@ -1490,13 +1491,13 @@ type IfUnmodifiedSince =
           Format = ifUnmodifiedSinceF }
 
     static member Format =
-        Formatting.format IfUnmodifiedSince.TypeMapping.Format
+        Formatting.format IfUnmodifiedSince.Mapping.Format
 
     static member Parse =
-        Parsing.parse IfUnmodifiedSince.TypeMapping.Parse
+        Parsing.parse IfUnmodifiedSince.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse IfUnmodifiedSince.TypeMapping.Parse
+        Parsing.tryParse IfUnmodifiedSince.Mapping.Parse
 
     override x.ToString () =
         IfUnmodifiedSince.Format x
@@ -1516,27 +1517,27 @@ type IfUnmodifiedSince =
 type IfRange =
     | IfRange of IfRangeChoice
 
-    static member TypeMapping =
+    static member Mapping =
 
         let ifRangeP =
-            (EntityTag.TypeMapping.Parse |>> (EntityTag >> IfRange)) <|> 
+            (EntityTag.Mapping.Parse |>> (EntityTag >> IfRange)) <|> 
                                              (httpDateP |>> (Date >> IfRange))
 
         let ifRangeF =
             function | IfRange (Date x) -> append (x.ToString "r")
-                     | IfRange (EntityTag x) -> EntityTag.TypeMapping.Format x
+                     | IfRange (EntityTag x) -> EntityTag.Mapping.Format x
         
         { Parse = ifRangeP
           Format = ifRangeF }
 
     static member Format =
-        Formatting.format IfRange.TypeMapping.Format
+        Formatting.format IfRange.Mapping.Format
 
     static member Parse =
-        Parsing.parse IfRange.TypeMapping.Parse
+        Parsing.parse IfRange.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse IfRange.TypeMapping.Parse
+        Parsing.tryParse IfRange.Mapping.Parse
 
     override x.ToString () =
         IfRange.Format x
@@ -1560,7 +1561,7 @@ and IfRangeChoice =
 type Age =
     | Age of TimeSpan
 
-    static member TypeMapping =
+    static member Mapping =
 
         let ageP =
             puint32 |>> (float >> TimeSpan.FromSeconds >> Age)
@@ -1572,13 +1573,13 @@ type Age =
           Format = ageF }
 
     static member Format =
-        Formatting.format Age.TypeMapping.Format
+        Formatting.format Age.Mapping.Format
 
     static member Parse =
-        Parsing.parse Age.TypeMapping.Parse
+        Parsing.parse Age.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Age.TypeMapping.Parse
+        Parsing.tryParse Age.Mapping.Parse
 
     override x.ToString () =
         Age.Format x
@@ -1596,25 +1597,25 @@ type Age =
 type CacheControl =
     | CacheControl of CacheDirective list
 
-    static member TypeMapping =
+    static member Mapping =
 
         let cacheControlP =
-            infix1P CacheDirective.TypeMapping.Parse commaP |>> CacheControl
+            infix1P CacheDirective.Mapping.Parse commaP |>> CacheControl
 
         let cacheControlF =
-            function | CacheControl x -> join CacheDirective.TypeMapping.Format commaF x
+            function | CacheControl x -> join CacheDirective.Mapping.Format commaF x
 
         { Parse = cacheControlP
           Format = cacheControlF }
 
     static member Format =
-        Formatting.format CacheControl.TypeMapping.Format
+        Formatting.format CacheControl.Mapping.Format
 
     static member Parse =
-        Parsing.parse CacheControl.TypeMapping.Parse
+        Parsing.parse CacheControl.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse CacheControl.TypeMapping.Parse
+        Parsing.tryParse CacheControl.Mapping.Parse
 
     override x.ToString () =
         CacheControl.Format x
@@ -1634,7 +1635,7 @@ and CacheDirective =
     | SMaxAge of TimeSpan
     | Custom of string * string option
 
-    static member TypeMapping =
+    static member Mapping =
 
         // TODO: Custom Directive Parsing
 
@@ -1680,7 +1681,7 @@ and CacheDirective =
 type Expires =
     | Expires of DateTime
 
-    static member TypeMapping =
+    static member Mapping =
 
         let expiresP =
             httpDateP |>> Expires
@@ -1692,13 +1693,13 @@ type Expires =
           Format = expiresF }
 
     static member Format =
-        Formatting.format Expires.TypeMapping.Format
+        Formatting.format Expires.Mapping.Format
 
     static member Parse =
-        Parsing.parse Expires.TypeMapping.Parse
+        Parsing.parse Expires.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Expires.TypeMapping.Parse
+        Parsing.tryParse Expires.Mapping.Parse
 
     override x.ToString () =
         Expires.Format x

--- a/src/Freya.Types.Language/Types.fs
+++ b/src/Freya.Types.Language/Types.fs
@@ -21,8 +21,6 @@ module Freya.Types.Language
 
 open System.ComponentModel
 open Freya.Types
-open Freya.Types.Formatting
-open Freya.Types.Parsing
 open FParsec
 
 (* RFC 5646
@@ -46,23 +44,21 @@ open FParsec
 
 (* Helpers *)
 
-let private isAlpha =
-    ((?>) Grammar.alpha)
-
-let private isDigit =
-    ((?>) Grammar.digit)
-
-let private isAlphaNum x =
-    (Grammar.alpha ?> x || Grammar.digit ?> x)
+let private alphaDigit i =
+        (Grammar.alpha i)
+     || (Grammar.digit i)
 
 let private alphaP min max =
-    manyMinMaxSatisfy min max isAlpha .>>? notFollowedBy (skipSatisfy isAlpha)
+         manyMinMaxSatisfy min max (int >> Grammar.alpha) 
+    .>>? notFollowedBy (skipSatisfy (int >> Grammar.alpha))
 
 let private digitP min max =
-    manyMinMaxSatisfy min max isDigit .>>? notFollowedBy (skipSatisfy isDigit)
+         manyMinMaxSatisfy min max (int >> Grammar.digit) 
+    .>>? notFollowedBy (skipSatisfy (int >> Grammar.digit))
 
 let private alphaNumP min max =
-    manyMinMaxSatisfy min max isAlphaNum .>>? notFollowedBy (skipSatisfy isAlphaNum)
+         manyMinMaxSatisfy min max (int >> alphaDigit) 
+    .>>? notFollowedBy (skipSatisfy (int >> alphaDigit))
 
 (* Language *)
 

--- a/src/Freya.Types.Language/Types.fs
+++ b/src/Freya.Types.Language/Types.fs
@@ -70,7 +70,7 @@ type Language =
     | Language of string * string list option
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let extP =
             skipChar '-' >>. alphaP 3 3
@@ -101,13 +101,13 @@ type Language =
           Format = languageF }
 
     static member Format =
-        Formatting.format Language.TypeMapping.Format
+        Formatting.format Language.Mapping.Format
 
     static member Parse =
-        Parsing.parse Language.TypeMapping.Parse
+        Parsing.parse Language.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse Language.TypeMapping.Parse
+        Parsing.tryParse Language.Mapping.Parse
 
     override x.ToString () =
         Language.Format x
@@ -118,7 +118,7 @@ type Script =
     | Script of string
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let scriptP =
             skipChar '-' >>. alphaP 4 4 |>> Script
@@ -135,7 +135,7 @@ type Region =
     | Region of string
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let regionP =
             skipChar '-' >>. (alphaP 2 2 <|> digitP 3 3) |>> Region
@@ -152,7 +152,7 @@ type Variant =
     | Variant of string list
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let alphaPrefixVariantP =
             alphaNumP 5 8
@@ -181,23 +181,23 @@ type LanguageTag =
     | LanguageTag of Language * Script option * Region option * Variant
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let languageTagP =
-            tuple4 Language.TypeMapping.Parse 
-                   (opt (attempt Script.TypeMapping.Parse))
-                   (opt (attempt Region.TypeMapping.Parse))
-                   (Variant.TypeMapping.Parse)
+            tuple4 Language.Mapping.Parse 
+                   (opt (attempt Script.Mapping.Parse))
+                   (opt (attempt Region.Mapping.Parse))
+                   (Variant.Mapping.Parse)
             |>> fun (language, script, region, variant) ->
                 LanguageTag (language, script, region, variant)
 
         let languageTagF =
             function | LanguageTag (language, script, region, variant) ->
                          let formatters =
-                            [ Language.TypeMapping.Format language
-                              (function | Some x -> Script.TypeMapping.Format x | _ -> id) script
-                              (function | Some x -> Region.TypeMapping.Format x | _ -> id) region
-                              Variant.TypeMapping.Format variant ]
+                            [ Language.Mapping.Format language
+                              (function | Some x -> Script.Mapping.Format x | _ -> id) script
+                              (function | Some x -> Region.Mapping.Format x | _ -> id) region
+                              Variant.Mapping.Format variant ]
 
                          fun b -> List.fold (|>) b formatters
 
@@ -205,13 +205,13 @@ type LanguageTag =
           Format = languageTagF }
 
     static member Format =
-        Formatting.format LanguageTag.TypeMapping.Format
+        Formatting.format LanguageTag.Mapping.Format
 
     static member Parse =
-        Parsing.parse LanguageTag.TypeMapping.Parse
+        Parsing.parse LanguageTag.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse LanguageTag.TypeMapping.Parse
+        Parsing.tryParse LanguageTag.Mapping.Parse
 
     override x.ToString () =
         LanguageTag.Format x
@@ -228,7 +228,7 @@ type LanguageRange =
     | Any
 
     [<EditorBrowsable (EditorBrowsableState.Never)>]
-    static member TypeMapping =
+    static member Mapping =
 
         let languageRangeP =
             choice [
@@ -244,13 +244,13 @@ type LanguageRange =
           Format = languageRangeF }
 
     static member Format =
-        Formatting.format LanguageRange.TypeMapping.Format
+        Formatting.format LanguageRange.Mapping.Format
 
     static member Parse =
-        Parsing.parse LanguageRange.TypeMapping.Parse
+        Parsing.parse LanguageRange.Mapping.Parse
 
     static member TryParse =
-        Parsing.tryParse LanguageRange.TypeMapping.Parse
+        Parsing.tryParse LanguageRange.Mapping.Parse
 
     override x.ToString () =
         LanguageRange.Format x

--- a/src/Freya.Types.Uri.Template/Freya.Types.Uri.Template.fsproj
+++ b/src/Freya.Types.Uri.Template/Freya.Types.Uri.Template.fsproj
@@ -1,20 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>af48f7da-f8e4-4c46-89b6-5dd9a09dbabf</ProjectGuid>
-    <ProjectGuid>{EF160EBE-806E-4F88-81AC-B9488EDE1085}</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>cd9e9bc2-b760-4414-9f78-f0cd1a6bd721</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Freya.Types</RootNamespace>
-    <AssemblyName>Freya.Types</AssemblyName>
+    <RootNamespace>Freya.Types.Uri.Template</RootNamespace>
+    <AssemblyName>Freya.Types.Uri.Template</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
-    <Name>Freya.Types</Name>
-    <Name>Freya.Typed</Name>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <Name>Freya.Types.Uri.Template</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,7 +21,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\Freya.Types.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\Freya.Types.Uri.Template.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +30,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\Freya.Types.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\Freya.Types.Uri.Template.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
@@ -50,21 +47,9 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  <Import Project="$(FSharpTargetsPath)" />
   <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Types.fs" />
-    <Compile Include="Formatting.fs" />
-    <Compile Include="Parsing.fs" />
-    <Compile Include="Rendering.fs" />
-    <Compile Include="Grammar.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
@@ -72,6 +57,25 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Freya.Types.Uri\Freya.Types.Uri.fsproj">
+      <Name>Freya.Types.Uri</Name>
+      <Project>{8a5ac05b-cb43-43b0-a763-992d1a04d271}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Freya.Types\Freya.Types.fsproj">
+      <Name>Freya.Types</Name>
+      <Project>{ef160ebe-806e-4f88-81ac-b9488ede1085}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
       <ItemGroup>

--- a/src/Freya.Types.Uri.Template/Freya.Types.Uri.Template.fsproj.paket.references
+++ b/src/Freya.Types.Uri.Template/Freya.Types.Uri.Template.fsproj.paket.references
@@ -1,0 +1,2 @@
+FParsec
+FSharp.Core

--- a/src/Freya.Types.Uri.Template/Types.fs
+++ b/src/Freya.Types.Uri.Template/Types.fs
@@ -1,0 +1,456 @@
+﻿//----------------------------------------------------------------------------
+//
+// Copyright (c) 2014
+//
+//    Ryan Riley (@panesofglass) and Andrew Cherry (@kolektiv)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//----------------------------------------------------------------------------
+
+module Freya.Types.Uri.Template
+
+open Freya.Types
+open Freya.Types.Uri
+open FParsec
+
+(* RFC 6570
+
+   Types, parsers and formatters implemented to mirror the specification of 
+   URI Template semantics as defined in RFC 6570.
+
+   Taken from [http://tools.ietf.org/html/rfc6570] *)
+
+(* Grammar
+
+   NOTE: We do not currently support IRIs - this may
+   be supported in future. *)
+
+[<RequireQualifiedAccess>]
+module Grammar =
+
+    let literal i =
+            (i = 0x21)
+         || (i >= 0x23 && i <= 0x24)
+         || (i = 0x26)
+         || (i >= 0x28 && i <= 0x3b)
+         || (i = 0x3d)
+         || (i >= 0x3f && i <= 0x5b)
+         || (i = 0x5d)
+         || (i = 0x5f)
+         || (i >= 0x61 && i <= 0x7a)
+         || (i = 0x7e)
+
+    let varchar i =
+            (Grammar.alpha i)
+         || (Grammar.digit i)
+         || (i = 0x5f) // _
+
+(* Template
+
+   Taken from RFC 6570, Section 2 Syntax
+   See [http://tools.ietf.org/html/rfc6570#section-2] *)
+
+type UriTemplate =
+    | UriTemplate of UriTemplatePart list
+
+    static member Mapping =
+
+        let uriTemplateP =
+            many1 UriTemplatePart.Mapping.Parse |>> UriTemplate
+
+        let uriTemplateF =
+            function | UriTemplate u -> join UriTemplatePart.Mapping.Format id u
+
+        { Parse = uriTemplateP
+          Format = uriTemplateF }
+
+    static member Rendering =
+
+        let uriTemplateR (data: UriTemplateData) =
+            function | UriTemplate p -> join (UriTemplatePart.Rendering.Render data) id p
+
+        { Render = uriTemplateR }
+
+    static member Format =
+        Formatting.format UriTemplate.Mapping.Format
+
+    static member Parse =
+        Parsing.parse UriTemplate.Mapping.Parse
+
+    static member TryParse =
+        Parsing.tryParse UriTemplate.Mapping.Parse
+
+    static member (+) (UriTemplate a, UriTemplate b) =
+        UriTemplate (a @ b)
+
+    override x.ToString () =
+        UriTemplate.Format x
+
+    member x.Render data =
+        Rendering.render UriTemplate.Rendering.Render data x
+
+and UriTemplatePart =
+    | Literal of Literal
+    | Expression of Expression
+
+    static member Mapping =
+
+        let uriTemplatePartP =
+            (Expression.Mapping.Parse |>> Expression) <|> (Literal.Mapping.Parse |>> Literal)
+
+        let uriTemplatePartF =
+            function | Literal l -> Literal.Mapping.Format l
+                     | Expression e -> Expression.Mapping.Format e
+
+        { Parse = uriTemplatePartP
+          Format = uriTemplatePartF }
+
+    static member Rendering =
+
+        let uriTemplatePartR data =
+            function | Literal l -> Literal.Rendering.Render data l
+                     | Expression e-> Expression.Rendering.Render data e
+
+        { Render = uriTemplatePartR }
+
+and Literal =
+    | Literal of string
+
+    static member Mapping =
+
+        let parser =
+            PercentEncoding.makeParser Grammar.literal
+
+        let formatter =
+            PercentEncoding.makeFormatter Grammar.literal
+
+        let literalP =
+            notEmpty parser |>> Literal.Literal
+
+        let literalF =
+            function | Literal l -> formatter l
+
+        { Parse = literalP
+          Format = literalF }
+
+    static member Rendering =
+
+        let literalR _ =
+            function | Literal l -> append l
+
+        { Render = literalR }
+
+and Expression =
+    | Expression of Operator option * VariableList
+
+    static member Mapping =
+
+        let expressionP =
+            between 
+                (skipChar '{') (skipChar '}') 
+                (opt Operator.Mapping.Parse .>>. VariableList.Mapping.Parse)
+                |>> Expression
+
+        let expressionF =
+            function | Expression (Some o, v) ->
+                           append "{"
+                        >> Operator.Mapping.Format o
+                        >> VariableList.Mapping.Format v
+                        >> append "}"
+                     | Expression (_, v) ->
+                           append "{"
+                        >> VariableList.Mapping.Format v
+                        >> append "}"
+
+        { Parse = expressionP
+          Format = expressionF }
+
+    static member Rendering =
+
+        (* Expansion *)
+
+        let choose (VariableList variableList) (UriTemplateData data) =
+            variableList
+            |> List.map (fun (VariableSpec (VariableName n, m)) ->
+                match Map.tryFind n data with
+                | None -> None
+                | Some (List []) -> None
+                | Some (Keys []) -> None
+                | Some x -> Some (x, m))
+            |> List.choose id
+
+        let expand f s =
+            function | (Atom a, Some (Level4 (Prefix i))) -> f (a.Substring (0, min i a.Length))
+                     | (Atom a, _) -> f a
+                     | (List l, Some (Level4 (Explode))) -> join f s l
+                     | (List l, _) -> join f commaF l
+                     | (Keys k, Some (Level4 (Explode))) -> join (fun (k, v) -> f k >> equalsF >> f v) s k
+                     | (Keys k, _) -> join (fun (k, v) -> f k >> commaF >> f v) commaF k
+
+        let render f variableList data =
+            match choose variableList data with
+            | [] -> id
+            |  data -> f data
+
+        (* Simple Expansion *)
+
+        let simpleF =
+            PercentEncoding.makeFormatter Grammar.unreserved
+
+        let simpleExpansion =
+            render (join (expand simpleF commaF) commaF)
+
+        (* Reserved Expansion *)
+
+        let reserved i =
+                (Grammar.reserved i)
+             || (Grammar.unreserved i)
+
+        let reservedF =
+            PercentEncoding.makeFormatter reserved
+
+        let reservedExpansion =
+            render (join (expand reservedF commaF) commaF)
+
+        (* Fragment Expansion *)
+
+        let fragmentExpansion =
+            render (fun d -> append "#" >> join (expand reservedF commaF) commaF d)
+
+        (* Label Expansion with Dot-Prefix *)
+
+        let labelExpansion =
+            render (fun d -> dotF >> join (expand simpleF dotF) dotF d)
+
+        (* Expression *)
+
+        let expressionR data =
+            function | Expression (None, v) -> simpleExpansion v data
+                     | Expression (Some (Level2 Plus), v) -> reservedExpansion v data
+                     | Expression (Some (Level2 Hash), v) -> fragmentExpansion v data
+                     | Expression (Some (Level3 Dot), v) -> labelExpansion v data
+                     | Expression (Some (Level3 Slash), _) -> id
+                     | Expression (Some (Level3 SemiColon), _) -> id
+                     | Expression (Some (Level3 Question), _) -> id
+                     | Expression (Some (Level3 Ampersand), _) -> id
+                     | _ -> id
+
+        { Render = expressionR }
+
+(* Operators
+
+   Taken from RFC 6570, Section 2.2 Expressions
+   See [http://tools.ietf.org/html/rfc6570#section-2.2] *)
+
+and Operator =
+    | Level2 of OperatorLevel2
+    | Level3 of OperatorLevel3
+    | Reserved of OperatorReserved
+
+    static member Mapping =
+
+        let operatorP =
+            choice [
+                OperatorLevel2.Mapping.Parse |>> Level2
+                OperatorLevel3.Mapping.Parse |>> Level3
+                OperatorReserved.Mapping.Parse |>> Reserved ]
+
+        let operatorF =
+            function | Level2 o -> OperatorLevel2.Mapping.Format o
+                     | Level3 o -> OperatorLevel3.Mapping.Format o
+                     | Reserved o -> OperatorReserved.Mapping.Format o
+
+        { Parse = operatorP
+          Format = operatorF }
+
+and OperatorLevel2 =
+    | Plus
+    | Hash
+
+    static member Mapping =
+
+        let operatorLevel2P =
+            choice [
+                skipChar '+' >>% Plus
+                skipChar '#' >>% Hash ]
+
+        let operatorLevel2F =
+            function | Plus -> append "+"
+                     | Hash -> append "#"
+
+        { Parse = operatorLevel2P
+          Format = operatorLevel2F }
+
+and OperatorLevel3 =
+    | Dot
+    | Slash
+    | SemiColon
+    | Question
+    | Ampersand
+
+    static member Mapping =
+
+        let operatorLevel3P =
+            choice [
+                skipChar '.' >>% Dot
+                skipChar '/' >>% Slash
+                skipChar ';' >>% SemiColon
+                skipChar '?' >>% Question
+                skipChar '&' >>% Ampersand ]
+
+        let operatorLevel3F =
+            function | Dot -> append "."
+                     | Slash -> append "/"
+                     | SemiColon -> append ";"
+                     | Question -> append "?"
+                     | Ampersand -> append "&"
+
+        { Parse = operatorLevel3P
+          Format = operatorLevel3F }
+
+and OperatorReserved =
+    | Equals
+    | Comma
+    | Exclamation
+    | At
+    | Pipe
+
+    static member Mapping =
+
+        let operatorReservedP =
+            choice [
+                skipChar '=' >>% Equals
+                skipChar ',' >>% Comma
+                skipChar '!' >>% Exclamation
+                skipChar '@' >>% At
+                skipChar '|' >>% Pipe ]
+
+        let operatorReservedF =
+            function | Equals -> append "="
+                     | Comma -> append ","
+                     | Exclamation -> append "!"
+                     | At -> append "@"
+                     | Pipe -> append "!"
+
+        { Parse = operatorReservedP
+          Format = operatorReservedF }
+
+(* Variables
+
+   Taken from RFC 6570, Section 2.3 Variables
+   See [http://tools.ietf.org/html/rfc6570#section-2.3] *)
+
+and VariableList =
+    | VariableList of VariableSpec list
+
+    static member Mapping =
+
+        let variableListP =
+            sepBy1 VariableSpec.Mapping.Parse (skipChar ',')
+            |>> VariableList
+
+        let variableListF =
+            function | VariableList v -> join VariableSpec.Mapping.Format commaF v
+
+        { Parse = variableListP
+          Format = variableListF }
+
+and VariableSpec =
+    | VariableSpec of VariableName * Modifier option
+
+    static member Mapping =
+
+        let variableSpecP =
+            VariableName.Mapping.Parse .>>. opt Modifier.Mapping.Parse
+            |>> VariableSpec
+
+        let variableSpecF =
+            function | VariableSpec (name, Some m) ->
+                           VariableName.Mapping.Format name
+                        >> Modifier.Mapping.Format m
+                     | VariableSpec (name, _) ->
+                        VariableName.Mapping.Format name
+
+        { Parse = variableSpecP
+          Format = variableSpecF }
+
+and VariableName =
+    | VariableName of string list
+
+    static member Mapping =
+
+        let parser =
+            PercentEncoding.makeParser Grammar.varchar
+
+        let formatter =
+            PercentEncoding.makeFormatter Grammar.varchar
+
+        let variableNameP =
+            sepBy1 (notEmpty parser) (skipChar '.') |>> VariableName
+
+        let variableNameF =
+            function | VariableName n ->join formatter (append ".") n
+
+        { Parse = variableNameP
+          Format = variableNameF }
+
+(* Modifiers
+
+   Taken from RFC 6570, Section 2.4 Value Modifiers
+   See [http://tools.ietf.org/html/rfc6570#section-2.4] *)
+
+and Modifier =
+    | Level4 of ModifierLevel4
+
+    static member Mapping =
+
+        let modifierP =
+            ModifierLevel4.Mapping.Parse |>> Level4
+
+        let modifierF =
+            function | Level4 m -> ModifierLevel4.Mapping.Format m
+
+        { Parse = modifierP
+          Format = modifierF }
+
+and ModifierLevel4 =
+    | Prefix of int
+    | Explode
+
+    static member Mapping =
+
+        let modifierLevel4P =
+            choice [
+                skipChar ':' >>. pint32 |>> Prefix
+                skipChar '*' >>% Explode ]
+
+        let modifierLevel4F =
+            function | Prefix i -> appendf1 ":{0}" i
+                     | Explode -> append "*"
+
+        { Parse = modifierLevel4P
+          Format = modifierLevel4F }
+
+(* Data
+
+   Types representing data which may be rendered or extracted
+   using UriTemplates. *)
+
+and UriTemplateData =
+    | UriTemplateData of Map<string list, UriTemplateDataItem>
+
+and UriTemplateDataItem =
+    | Atom of string
+    | List of string list
+    | Keys of (string * string) list

--- a/src/Freya.Types/Formatting.fs
+++ b/src/Freya.Types/Formatting.fs
@@ -58,6 +58,12 @@ let ampersandF : Separator =
 let commaF : Separator =
     append ","
 
+let dotF : Separator =
+    append "."
+
+let equalsF : Separator =
+    append "="
+
 let semicolonF : Separator =
     append ";"
 

--- a/src/Freya.Types/Formatting.fs
+++ b/src/Freya.Types/Formatting.fs
@@ -24,8 +24,8 @@ open System.Text
 
 (* Formatting *)
 
-let format (formatter: 'a -> StringBuilder -> StringBuilder) =
-    fun a -> string (formatter a (StringBuilder ()))
+let format (format: Format<'a>) =
+    fun a -> string (format a (StringBuilder ()))
 
 (* Helpers *)
 

--- a/src/Freya.Types/Grammar.fs
+++ b/src/Freya.Types/Grammar.fs
@@ -19,39 +19,38 @@
 
 module Freya.Types.Grammar
 
-open Parsing
-
 (* RFC 5234
 
-   Core ABNF grammar rules as defined in RFC 5234.
+   Core ABNF grammar rules as defined in RFC 5234, expressed
+   as predicates over integer character codes.
+
    Taken from RFC 5234, Appendix B.1 Core Rules
    See [http://tools.ietf.org/html/rfc5234#appendix-B.1] *)
 
-let alpha = 
-    Set.unionMany [ 
-        charRange 0x41 0x5a
-        charRange 0x61 0x7a ]
+let alpha i =
+        (i >= 0x41 && i <= 0x5a)
+     || (i >= 0x61 && i <= 0x7a)
 
-let digit = 
-    charRange 0x30 0x39
+let digit i =
+        (i >= 0x30 && i <= 0x39)
 
-let dquote = 
-    char 0x22
+let dquote i =
+        (i = 0x22)
 
-let htab = 
-    char 0x09
+let hexdig i =
+        (digit i)
+     || (i >= 0x41 && i <= 0x46)
+     || (i >= 0x61 && i <= 0x66)
 
-let sp = 
-    char 0x20
+let htab i =
+        (i = 0x09)
 
-let vchar =
-    charRange 0x21 0x7e
+let sp i =
+        (i = 0x20)
 
-let hexdig =
-    Set.unionMany [
-        digit
-        set [ 'A'; 'B'; 'C'; 'D'; 'E'; 'F'
-              'a'; 'b'; 'c'; 'd'; 'e'; 'f' ] ]
+let vchar i =
+        (i >= 0x21 && i <= 0x7e)
 
-let wsp = 
-    set [ sp; htab ]
+let wsp i =
+        (htab i)
+     || (sp i)

--- a/src/Freya.Types/Parsing.fs
+++ b/src/Freya.Types/Parsing.fs
@@ -34,15 +34,7 @@ let tryParse (p: Parse<'a>) s =
     | Success (x, _, _) -> Some x
     | Failure (_, _, _) -> None
 
-(* Helpers *)
-
-let charRange x y =
-    set (List.map char [ x .. y ])
-
-let (?>) xs x =
-    Set.contains x xs
-
-(* Common *)
+(* Common Parsers *)
 
 let ampersandP : Parser<unit, unit> =
     skipChar '&'

--- a/src/Freya.Types/Rendering.fs
+++ b/src/Freya.Types/Rendering.fs
@@ -15,31 +15,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 //----------------------------------------------------------------------------
 
 [<AutoOpen>]
-module Freya.Types.Types
+module Freya.Types.Rendering
 
 open System.Text
-open FParsec
 
-(* Mapping *)
+(* Formatting *)
 
-type Mapping<'a> =
-    { Parse: Parse<'a>
-      Format: Format<'a> }
-
-and Parse<'a> =
-    Parser<'a,unit>
-
-and Format<'a> =
-    'a -> StringBuilder -> StringBuilder
-
-(* Rendering *)
-
-type Rendering<'a,'d> =
-    { Render: Render<'a,'d> }
-
-and Render<'a,'d> =
-    'd -> 'a -> StringBuilder -> StringBuilder
+let render (render: Render<'a,'d>) =
+    fun d a -> string (render d a (StringBuilder ()))

--- a/src/Freya.Types/Types.fs
+++ b/src/Freya.Types/Types.fs
@@ -24,7 +24,7 @@ module Freya.Types.Types
 open System.Text
 open FParsec
 
-type TypeMapping<'a> =
+type Mapping<'a> =
     { Parse: Parse<'a>
       Format: Format<'a> }
 

--- a/tests/Freya.Machine.Tests/Api.fs
+++ b/tests/Freya.Machine.Tests/Api.fs
@@ -187,7 +187,7 @@ let todos =
         doDelete clearAction
         doPost addAction
         handleCreated addedHandler
-        handleOk listHandler } |> Machine.toPipeline
+        handleOk listHandler } |> FreyaMachine.toPipeline
 
 let todoMethods =
     freya {
@@ -204,7 +204,7 @@ let todo =
         methodsSupported todoMethods
         doDelete deleteAction
         doPatch updateAction
-        handleOk getHandler } |> Machine.toPipeline
+        handleOk getHandler } |> FreyaMachine.toPipeline
 
 (* Router
 
@@ -216,7 +216,7 @@ let todo =
 let todoRoutes =
     freyaRouter {
         resource "/" todos
-        resource "/:id" todo } |> Router.toPipeline
+        resource "/:id" todo } |> FreyaRouter.toPipeline
 
 (* Inspectors *)
 

--- a/tests/Freya.Router.Tests/Prelude.fs
+++ b/tests/Freya.Router.Tests/Prelude.fs
@@ -37,7 +37,7 @@ let private set i =
     Freya.setLensPartial testLens i *> next
 
 let private run meth path m =
-    let router = Router.toPipeline m
+    let router = FreyaRouter.toPipeline m
 
     Async.RunSynchronously ((   Freya.setLens Request.path path 
                              *> Freya.setLens Request.meth meth 

--- a/tests/Freya.Types.Http.Cors.Tests/Types.Tests.fs
+++ b/tests/Freya.Types.Http.Cors.Tests/Types.Tests.fs
@@ -14,7 +14,7 @@ let ``Origin Formatting/Parsing`` () =
             OriginListOrNull.Origins [
                 SerializedOrigin (
                     Scheme "http",
-                    Name "www.example.com",
+                    Name (RegName "www.example.com"),
                     Some (Port 8080)) ])
 
     let originString =
@@ -31,7 +31,7 @@ let ``AccessControlAllowOrigin Formatting/Parsing`` () =
                 OriginListOrNull.Origins [
                     SerializedOrigin (
                         Scheme "http",
-                        Name "www.example.com",
+                        Name (RegName "www.example.com"),
                         Some (Port 8080)) ]))
 
     let accessControlAllowOriginString =

--- a/tests/Freya.Types.Http.Tests/Types.Tests.fs
+++ b/tests/Freya.Types.Http.Tests/Types.Tests.fs
@@ -44,7 +44,7 @@ let ``ContentLength Formatting/Parsing`` () =
 [<Test>]
 let ``Host Formatting/Parsing`` () =
 
-    let hostTyped = Host (Name "www.example.com", Some (Port 8080))
+    let hostTyped = Host (Name (RegName "www.example.com"), Some (Port 8080))
     let hostString = "www.example.com:8080"
 
     roundTrip (Host.Format, Host.Parse) [

--- a/tests/Freya.Types.Uri.Template.Tests/App.config
+++ b/tests/Freya.Types.Uri.Template.Tests/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/Freya.Types.Uri.Template.Tests/Freya.Types.Uri.Template.Tests.fsproj
+++ b/tests/Freya.Types.Uri.Template.Tests/Freya.Types.Uri.Template.Tests.fsproj
@@ -1,20 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>af48f7da-f8e4-4c46-89b6-5dd9a09dbabf</ProjectGuid>
-    <ProjectGuid>{EF160EBE-806E-4F88-81AC-B9488EDE1085}</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>069c35a0-a4c7-423c-87f6-0a4ef964f95a</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Freya.Types</RootNamespace>
-    <AssemblyName>Freya.Types</AssemblyName>
+    <RootNamespace>Freya.Types.Uri.Template.Tests</RootNamespace>
+    <AssemblyName>Freya.Types.Uri.Template.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
-    <Name>Freya.Types</Name>
-    <Name>Freya.Typed</Name>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
+    <Name>Freya.Types.Uri.Template.Tests</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -24,7 +21,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\Freya.Types.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\Freya.Types.Uri.Template.Tests.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,7 +30,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\Freya.Types.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\Freya.Types.Uri.Template.Tests.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
@@ -50,7 +47,32 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
-  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Compile Include="Types.Tests.fs" />
+    <Content Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="mscorlib" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\Freya.Types.Uri.Template\Freya.Types.Uri.Template.fsproj">
+      <Name>Freya.Types.Uri.Template</Name>
+      <Project>{cd9e9bc2-b760-4414-9f78-f0cd1a6bd721}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Freya.Types\Freya.Types.fsproj">
+      <Name>Freya.Types</Name>
+      <Project>{ef160ebe-806e-4f88-81ac-b9488ede1085}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Freya.Types.Tests\Freya.Types.Tests.fsproj">
+      <Name>Freya.Types.Tests</Name>
+      <Project>{d39640c6-2258-4571-830e-7028e19db6ba}</Project>
+      <Private>True</Private>
+    </ProjectReference>
+  </ItemGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -58,20 +80,6 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <ItemGroup>
-    <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="Types.fs" />
-    <Compile Include="Formatting.fs" />
-    <Compile Include="Parsing.fs" />
-    <Compile Include="Rendering.fs" />
-    <Compile Include="Grammar.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Numerics" />
-  </ItemGroup>
   <Choose>
     <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
       <ItemGroup>
@@ -147,6 +155,33 @@
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\..\packages\FSharp.Core\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+      <Paket>True</Paket>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v5.0')">
+      <ItemGroup>
+        <Reference Include="Unquote">
+          <HintPath>..\..\packages\Unquote\lib\sl4\Unquote.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3')) Or ($(TargetFrameworkIdentifier) == 'MonoAndroid') Or ($(TargetFrameworkIdentifier) == 'MonoTouch')">
+      <ItemGroup>
+        <Reference Include="Unquote">
+          <HintPath>..\..\packages\Unquote\lib\net40\Unquote.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/tests/Freya.Types.Uri.Template.Tests/Freya.Types.Uri.Template.Tests.fsproj.paket.references
+++ b/tests/Freya.Types.Uri.Template.Tests/Freya.Types.Uri.Template.Tests.fsproj.paket.references
@@ -1,0 +1,4 @@
+FParsec
+FSharp.Core
+NUnit
+Unquote

--- a/tests/Freya.Types.Uri.Template.Tests/Types.Tests.fs
+++ b/tests/Freya.Types.Uri.Template.Tests/Types.Tests.fs
@@ -1,0 +1,140 @@
+﻿module Freya.Types.Uri.Templates.Tests
+
+open NUnit.Framework
+open Freya.Types.Uri.Template
+open Swensen.Unquote
+
+(* Data
+
+   Common superset of data items used throughout RFC 6570
+   to frame examples. *)
+
+let data =
+    UriTemplateData (
+        Map.ofList [
+            [ "count" ],      List [ "one"; "two"; "three" ]
+            [ "dom" ],        List [ "example"; "com" ]
+            [ "dub" ],        Atom "me/too"
+            [ "hello" ],      Atom "Hello World!"
+            [ "half" ],       Atom "50%"
+            [ "var" ],        Atom "value"
+            [ "who" ],        Atom "fred"
+            [ "base" ],       Atom "http://example.com/home/"
+            [ "path" ],       Atom "/foo/bar"
+            [ "list" ],       List [ "red"; "green"; "blue" ]
+            [ "keys" ],       Keys [ ("semi", ";"); ("dot", "."); ("comma", ",") ]
+            [ "v" ],          Atom "6"
+            [ "x" ],          Atom "1024"
+            [ "y" ],          Atom "768"
+            [ "empty" ],      Atom ""
+            [ "empty_keys" ], Keys [] ])
+
+let (=?) str1 str2 =
+    UriTemplate.Parse(str1).Render(data) =? str2
+
+(* Illustrative Examples
+
+   Examples used as part of the overview of URI Templates,
+   giving a non-exhaustive flavour of URI Template expansion
+   and variables/operators/modifiers. *)
+
+[<Test>]
+let ``Level 1 Examples Render Correctly`` () =
+
+    (* Simple String Expansion *)
+
+    "{var}" =? "value"
+    "{hello}" =? "Hello%20World%21"
+
+[<Test>]
+let ``Level 2 Examples Render Correctly`` () =
+
+    (* Reserved String Expansion *)
+
+    "{+var}" =? "value"
+    "{+hello}" =? "Hello%20World!"
+    "{+path}/here" =? "/foo/bar/here"
+    "here?ref={+path}" =? "here?ref=/foo/bar"
+
+    (* Fragment Expansion *)
+
+    "X{#var}" =? "X#value"
+    "X{#hello}" =? "X#Hello%20World!"
+
+(* Specifcation Examples
+
+   Examples given as part of individual specification sections
+   to drive the full set of expansion/modification cases, forming
+   a specification by example in addition to the grammars and
+   behaviours given as part of the specification. *)
+
+[<Test>]
+let ``Simple Expansion Renders Correctly`` () =
+    "{var}" =? "value"
+    "{hello}" =? "Hello%20World%21"
+    "{half}" =? "50%25"
+    "O{empty}X" =? "OX"
+    "O{undef}X" =? "OX"
+    "{x,y}" =? "1024,768"
+    "{x,hello,y}" =? "1024,Hello%20World%21,768"
+    "?{x,empty}" =? "?1024,"
+    "?{x,undef}" =? "?1024"
+    "?{undef,y}" =? "?768"
+    "{var:3}" =? "val"
+    "{var:30}" =? "value"
+    "{list}" =? "red,green,blue"
+    "{list*}" =? "red,green,blue"
+    "{keys}" =? "semi,%3B,dot,.,comma,%2C"
+    "{keys*}" =? "semi=%3B,dot=.,comma=%2C"
+
+[<Test>]
+let ``Reserved Expansion Renders Correctly`` () =
+    "{+var}" =? "value"
+    "{+hello}" =? "Hello%20World!"
+    "{+half}" =? "50%25"
+    "{base}index" =? "http%3A%2F%2Fexample.com%2Fhome%2Findex"
+    "{+base}index" =? "http://example.com/home/index"
+    "O{+empty}X" =? "OX"
+    "O{+undef}X" =? "OX"
+    "{+path}/here" =? "/foo/bar/here"
+    "here?ref={+path}" =? "here?ref=/foo/bar"
+    "up{+path}{var}/here" =? "up/foo/barvalue/here"
+    "{+x,hello,y}" =? "1024,Hello%20World!,768"
+    "{+path,x}/here" =? "/foo/bar,1024/here"
+    "{+path:6}/here" =? "/foo/b/here"
+    "{+list}" =? "red,green,blue"
+    "{+list*}" =? "red,green,blue"
+    "{+keys}" =? "semi,;,dot,.,comma,,"
+    "{+keys*}" =? "semi=;,dot=.,comma=,"
+
+[<Test>]
+let ``Fragment Expansion Renders Correctly`` () =
+    "{#var}" =? "#value"
+    "{#hello}" =? "#Hello%20World!"
+    "{#half}" =? "#50%25"
+    "foo{#empty}" =? "foo#"
+    "foo{#undef}" =? "foo"
+    "{#x,hello,y}" =? "#1024,Hello%20World!,768"
+    "{#path,x}/here" =? "#/foo/bar,1024/here"
+    "{#path:6}/here" =? "#/foo/b/here"
+    "{#list}" =? "#red,green,blue"
+    "{#list*}" =? "#red,green,blue"
+    "{#keys}" =? "#semi,;,dot,.,comma,,"
+    "{#keys*}" =? "#semi=;,dot=.,comma=,"
+
+[<Test>]
+let ``Label Expansion with Dot-Prefix Renders Correctly`` () =
+    "{.who}" =? ".fred"
+    "{.who,who}" =? ".fred.fred"
+    "{.half,who}" =? ".50%25.fred"
+    "www{.dom*}" =? "www.example.com"
+    "X{.var}" =? "X.value"
+    "X{.empty}" =? "X."
+    "X{.undef}" =? "X"
+    "X{.var:3}" =? "X.val"
+    "X{.list}" =? "X.red,green,blue"
+    "X{.list*}" =? "X.red.green.blue"
+    "X{.keys}" =? "X.semi,%3B,dot,.,comma,%2C"
+    "X{.keys*}" =? "X.semi=%3B.dot=..comma=%2C"
+    "X{.empty_keys}" =? "X"
+    "X{.empty_keys*}" =? "X"

--- a/tests/Freya.Types.Uri.Tests/Types.Tests.fs
+++ b/tests/Freya.Types.Uri.Tests/Types.Tests.fs
@@ -38,10 +38,10 @@ let ``Authority Formatting/Parsing`` () =
     (* Host, Port and UserInfo *)
 
     let hostPortUserTyped =
-        Authority.Authority (Name "www.example.com", Some (Port 8080),Some (UserInfo "user:pass"))
+        Authority.Authority (Name (RegName "www.example.com"), Some (Port 8080),Some (UserInfo "user name:pass"))
 
     let hostPortUserString =
-        "user:pass@www.example.com:8080"
+        "user%20name:pass@www.example.com:8080"
 
     (* Round Trip *)
 
@@ -54,10 +54,10 @@ let ``Authority Formatting/Parsing`` () =
 let ``PathAbsoluteOrEmpty Formatting/Parsing`` () =
 
     let pathAbEmptyFullTyped = 
-        PathAbsoluteOrEmpty [ "some"; "path" ]
+        PathAbsoluteOrEmpty [ "some value?"; "path" ]
 
     let pathAbEmptyFullString =
-        "/some/path"
+        "/some%20value%3F/path"
 
     let pathAbEmptyEmptyTyped = 
         PathAbsoluteOrEmpty []
@@ -73,10 +73,10 @@ let ``PathAbsoluteOrEmpty Formatting/Parsing`` () =
 let ``PathAbsolute Formatting/Parsing`` () =
 
     let pathAbsoluteFullTyped = 
-        PathAbsolute [ "some"; "path" ]
+        PathAbsolute [ "some value?"; "path" ]
 
     let pathAbsoluteFullString =
-        "/some/path"
+        "/some%20value%3F/path"
 
     let pathAbsoluteEmptyTyped = 
         PathAbsolute []
@@ -97,13 +97,13 @@ let ``Uri Formatting/Parsing`` () =
         Uri.Uri (
             Scheme "http",
             HierarchyPart.Authority (
-                Authority.Authority (Name "www.example.com", Some (Port 8080), Some (UserInfo "user:pass")),
+                Authority.Authority (Name (RegName "www.example.com"), Some (Port 8080), Some (UserInfo "user name:pass")),
                 PathAbsoluteOrEmpty [ "seg1"; "seg2" ]),
-            Some (Query "key=val"),
+            Some (Query "key=some value"),
             Some (Fragment "frag1"))
 
     let authorityString =
-        "http://user:pass@www.example.com:8080/seg1/seg2?key=val#frag1"
+        "http://user%20name:pass@www.example.com:8080/seg1/seg2?key=some%20value#frag1"
 
     (* Rootless Hierarchy *)
 


### PR DESCRIPTION
Type system has some potential parser optimisations, plus the dependency on Chiron has been updated to 1.0 public release (although this still needs some real world thrashing). URI Templates have been merged in to develop. These support level 1, 2 and some level 3 operators so far, with complete support for the RFC coming shortly.

Potential next steps are to align routing with URI Templates in some way (under consideration) plus to pick work back up on Hypermedia now URI Template support is richer.

URI Template support may need a neater system of working with data, particular around data keys (currently typed as string lists, which is probably too weak, and somewhat non-obvious).