### PR TITLE
Proper If-Modified-Since support

### DIFF
--- a/src/Freya.Machine.Extensions.Http/Defaults.fs
+++ b/src/Freya.Machine.Extensions.Http/Defaults.fs
@@ -64,8 +64,3 @@ let methodsSupported =
     Freya.init [
         GET
         HEAD ]
-
-(* Modification *)
-
-let lastModified =
-    Freya.init Option<DateTime>.None

--- a/tests/Freya.Machine.Extensions.Http.Tests/Freya.Machine.Extensions.Http.Tests.fsproj
+++ b/tests/Freya.Machine.Extensions.Http.Tests/Freya.Machine.Extensions.Http.Tests.fsproj
@@ -73,6 +73,11 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
+    <ProjectReference Include="..\..\src\Freya.Core\Freya.Core.fsproj">
+      <Name>Freya.Core</Name>
+      <Project>{1aae3d8f-196f-4868-88ab-47d860cf091f}</Project>
+      <Private>True</Private>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Freya.Machine.Extensions.Http\Freya.Machine.Extensions.Http.fsproj">
       <Name>Freya.Machine.Extensions.Http</Name>
       <Project>{F394E9C1-0681-4653-B946-30C4FBA1226F}</Project>

--- a/tests/Freya.Machine.Tests/Api.fs
+++ b/tests/Freya.Machine.Tests/Api.fs
@@ -76,6 +76,12 @@ let patchTodo =
    guarantee that these functions are idempotent within the scope of a
    request, allowing us to use them as part of multiple decisions safely. *)
 
+let lastModificationDate = DateTime (2015, 1, 1)
+
+let todoLastModified =
+    freya {
+        return lastModificationDate } |> Freya.memo
+
 let add =
     freya {
         let! newTodo = newTodo
@@ -170,7 +176,8 @@ let common =
         corsHeadersSupported corsHeaders
         corsOriginsSupported corsOrigins
         languagesSupported en
-        mediaTypesSupported json }
+        mediaTypesSupported json
+        lastModified todoLastModified }
 
 let todosMethods =
     freya {


### PR DESCRIPTION
Issue #133 arises from the incorrect type cast in `Configuration.tryGetOrElse`. Currently `lastModified` has type `Freya<DateTime>`, but `Freya<DateTime option>` is inferred from the usage of `Configuration.tryGetOrElse Properties.LastModified Defaults.lastModified config`.

I've tried to replace it with `DateTime` everywhere first, but has faced an issue with Arachne (it expects the type here to be `DateTime`, not `DateTime option`). So I've decided to remove `Defaults.lastModified` completely and write a simple converter from `Freya<DateTime> option` to `Freya<DateTime option>` instead (see `Decisions.lastModified`). Maybe that's what the original code was trying to achieve.

I understand that the `Defaults.lastModified` is a little messy, so I'll gladly receive any advice on how to improve it.

Also there're now tests for `If-Modified-Since`.